### PR TITLE
Cleanup demo script & some tests

### DIFF
--- a/knitter/publish-contracts.sh
+++ b/knitter/publish-contracts.sh
@@ -1,4 +1,6 @@
 #! /bin/sh
 set -x
 
+rm -rf ../farmer/src/test/resources/pacts
+mkdir -p ../farmer/src/test/resources/pacts
 cp ./target/pacts/* ../farmer/src/test/resources/pacts

--- a/knitter/src/test/java/org/sheepy/knitter/SweaterResourceTest.java
+++ b/knitter/src/test/java/org/sheepy/knitter/SweaterResourceTest.java
@@ -1,84 +1,32 @@
 package org.sheepy.knitter;
 
-import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-import java.util.Map;
-
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response.Status;
-
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
 
-import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
-import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
-import au.com.dius.pact.consumer.junit5.PactTestFor;
-import au.com.dius.pact.core.model.V4Pact;
-import au.com.dius.pact.core.model.annotations.Pact;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@PactTestFor(providerName = "farmer", port = "8096")
-@ExtendWith(PactConsumerTestExt.class)
 public class SweaterResourceTest {
-    @Pact(consumer = "knitter")
-    public V4Pact buyingASweater(PactDslWithProvider builder) {
-        var headers = Map.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
 
-        var woolOrderBody = newJsonBody(body ->
-          body
-            .stringValue("colour", "white")
-            .numberType("orderNumber")
-        ).build();
+    @InjectMock
+    @RestClient
+    FarmerService mock;
 
-        var woolBody = newJsonBody(body -> body.stringValue("colour", "white")).build();
-
-        return builder
-          .uponReceiving("post request")
-            .path("/wool/order")
-            .headers(headers)
-            .method(HttpMethod.POST)
-            .body(woolOrderBody)
-          .willRespondWith()
-            .status(Status.OK.getStatusCode())
-            .headers(headers)
-            .body(woolBody)
-          .toPact(V4Pact.class);
-    }
-
-    @Pact(consumer = "knitter")
-    public V4Pact buyingAPinkSweater(PactDslWithProvider builder) {
-        var headers = Map.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-
-        var woolOrderBody = newJsonBody(body ->
-          body
-            .stringValue("colour", "pink")
-            .numberType("orderNumber")
-        ).build();
-
-        var woolBody = newJsonBody(body -> body.stringValue("colour", "pink")).build();
-
-        return builder
-          .uponReceiving("post request for pink sweater")
-            .path("/wool/order")
-            .headers(headers)
-            .method(HttpMethod.POST)
-            .body(woolOrderBody)
-          .willRespondWith()
-            .status(418)
-            .headers(headers)
-            .body(woolBody)
-          .toPact(V4Pact.class);
+    @BeforeEach
+    public void setUp() {
+        when(mock.getWool(any())).thenReturn(new Skein("white"));
     }
 
     @Test
-    @PactTestFor(pactMethod = "buyingASweater")
     public void testSweaterEndpointForWhiteSweater() {
         SweaterOrder order = new SweaterOrder("white", 12);
         Sweater sweater = given()
@@ -91,19 +39,6 @@ public class SweaterResourceTest {
                 .extract().as(Sweater.class);
 
         assertEquals("white", sweater.getColour());
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "buyingAPinkSweater")
-    public void testSweaterEndpointForPinkSweater() {
-        SweaterOrder order = new SweaterOrder("pink", 10);
-        given()
-                .contentType(ContentType.JSON)
-                .body(order)
-                .when()
-                .post("/sweater/order")
-                .then()
-                .statusCode(418);
     }
 
 

--- a/knitter/src/test/java/org/sheepy/knitter/SweaterResourceTest.java
+++ b/knitter/src/test/java/org/sheepy/knitter/SweaterResourceTest.java
@@ -1,30 +1,84 @@
 package org.sheepy.knitter;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
-import io.restassured.http.ContentType;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.V4Pact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
+@PactTestFor(providerName = "farmer", port = "8096")
+@ExtendWith(PactConsumerTestExt.class)
 public class SweaterResourceTest {
+    @Pact(consumer = "knitter")
+    public V4Pact buyingASweater(PactDslWithProvider builder) {
+        var headers = Map.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
 
-    @InjectMock
-    @RestClient
-    FarmerService mock;
+        var woolOrderBody = newJsonBody(body ->
+          body
+            .stringValue("colour", "white")
+            .numberType("orderNumber")
+        ).build();
 
-    @BeforeEach
-    public void setUp() {
-        when(mock.getWool(any())).thenReturn(new Skein("white"));
+        var woolBody = newJsonBody(body -> body.stringValue("colour", "white")).build();
+
+        return builder
+          .uponReceiving("post request")
+            .path("/wool/order")
+            .headers(headers)
+            .method(HttpMethod.POST)
+            .body(woolOrderBody)
+          .willRespondWith()
+            .status(Status.OK.getStatusCode())
+            .headers(headers)
+            .body(woolBody)
+          .toPact(V4Pact.class);
+    }
+
+    @Pact(consumer = "knitter")
+    public V4Pact buyingAPinkSweater(PactDslWithProvider builder) {
+        var headers = Map.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        var woolOrderBody = newJsonBody(body ->
+          body
+            .stringValue("colour", "pink")
+            .numberType("orderNumber")
+        ).build();
+
+        var woolBody = newJsonBody(body -> body.stringValue("colour", "pink")).build();
+
+        return builder
+          .uponReceiving("post request for pink sweater")
+            .path("/wool/order")
+            .headers(headers)
+            .method(HttpMethod.POST)
+            .body(woolOrderBody)
+          .willRespondWith()
+            .status(418)
+            .headers(headers)
+            .body(woolBody)
+          .toPact(V4Pact.class);
     }
 
     @Test
+    @PactTestFor(pactMethod = "buyingASweater")
     public void testSweaterEndpointForWhiteSweater() {
         SweaterOrder order = new SweaterOrder("white", 12);
         Sweater sweater = given()
@@ -37,6 +91,19 @@ public class SweaterResourceTest {
                 .extract().as(Sweater.class);
 
         assertEquals("white", sweater.getColour());
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "buyingAPinkSweater")
+    public void testSweaterEndpointForPinkSweater() {
+        SweaterOrder order = new SweaterOrder("pink", 10);
+        given()
+                .contentType(ContentType.JSON)
+                .body(order)
+                .when()
+                .post("/sweater/order")
+                .then()
+                .statusCode(418);
     }
 
 


### PR DESCRIPTION
I went through the demo script and was able to get things to work, but some of the instructions were not clear, so I've updated them.

I also cleaned up some of the code a bit too.

Also, the `publish-contracts.sh` script did not work as-is. The `farmer/src/test/resources/pacts` directory did not exist, so the copy script instead copied the .json pact file as `farmer/src/test/resources/pacts`, which of course did not work when running the farmer contract tests.

I checked in `SweaterResourceTest` by accident and my IDE reordered the imports. That was my fault :( Sorry. I have all kinds of automatic import ordering settings in my IDE (yes, I am that OCD....).