### PR TITLE
WireMock demo and workaround for Quarkus 3 and MockServer issue.

### DIFF
--- a/knitter/pom.xml
+++ b/knitter/pom.xml
@@ -72,6 +72,15 @@
       <version>${pact.version}</version>
       <scope>provided</scope> <!-- This should be test scope, but see https://github.com/quarkiverse/quarkus-pact/issues/28 -->
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock-jre8 -->
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.35.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/knitter/src/test/java/org/sheepy/knitter/PactConsumerTestBase.java
+++ b/knitter/src/test/java/org/sheepy/knitter/PactConsumerTestBase.java
@@ -1,0 +1,30 @@
+package org.sheepy.knitter;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.sheepy.knitter.pactworkaround.PactMockServer;
+import org.sheepy.knitter.wiremock.InjectWireMock;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+public class PactConsumerTestBase {
+
+    @InjectWireMock
+    protected WireMockServer wiremock;
+
+    @BeforeEach
+    void initWiremockBeforeEach() {
+        wiremock.resetAll();
+        configureFor(new WireMock(this.wiremock));
+    }
+
+    protected void forwardToPactServer(/*final MockServer mockServer*/ final PactMockServer wrapper) {
+        wiremock.resetAll();
+        stubFor(any(anyUrl()).atPriority(1).willReturn(aResponse().proxiedFrom(wrapper.getUrl())));
+    }
+}

--- a/knitter/src/test/java/org/sheepy/knitter/SweaterResourceContractTest.java
+++ b/knitter/src/test/java/org/sheepy/knitter/SweaterResourceContractTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.core.model.PactSpecVersion;
+import io.quarkus.test.common.QuarkusTestResource;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -13,6 +16,9 @@ import jakarta.ws.rs.core.Response.Status;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.sheepy.knitter.pactworkaround.PactMockServerWorkaround;
+import org.sheepy.knitter.pactworkaround.PactMockServer;
+import org.sheepy.knitter.wiremock.WireMockQuarkusTestResource;
 
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -24,9 +30,13 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import io.restassured.http.ContentType;
 
 @ExtendWith(PactConsumerTestExt.class)
-@PactTestFor(providerName = "farmer", port = "8096")
+@PactTestFor(providerName = "farmer", pactVersion = PactSpecVersion.V4)
+@MockServerConfig(port = "0")
+@QuarkusTestResource(WireMockQuarkusTestResource.class)
 @QuarkusTest
-public class SweaterResourceContractTest {
+// I could not use the extension in the test base because of order.
+@ExtendWith(PactMockServerWorkaround.class)
+public class SweaterResourceContractTest extends PactConsumerTestBase {
 
 	@Pact(consumer = "knitter")
 	public V4Pact buyingASweater(PactDslWithProvider builder) {
@@ -58,7 +68,9 @@ public class SweaterResourceContractTest {
 
 	@Test
 	@PactTestFor(pactMethod = "buyingASweater")
-	public void testSweaterEndpointForWhiteSweater() {
+	public void testSweaterEndpointForWhiteSweater(/*final MockServer mockServer*/final PactMockServer wrapper) {
+        forwardToPactServer(wrapper);
+
 		SweaterOrder order = new SweaterOrder("white", 12);
 		Sweater sweater = given().contentType(ContentType.JSON).body(order).when().post("/sweater/order").then().statusCode(200).extract().as(Sweater.class);
 
@@ -67,7 +79,9 @@ public class SweaterResourceContractTest {
 
 	@Test
 	@PactTestFor(pactMethod = "buyingAPinkSweater")
-	public void testSweaterEndpointForPinkSweater() {
+	public void testSweaterEndpointForPinkSweater(/*final MockServer mockServer*/final PactMockServer wrapper) {
+        forwardToPactServer(wrapper);
+
 		SweaterOrder order = new SweaterOrder("pink", 16);
 		Sweater sweater = given().contentType(ContentType.JSON).body(order).when().post("/sweater/order").then().statusCode(200).extract().as(Sweater.class);
 

--- a/knitter/src/test/java/org/sheepy/knitter/pactworkaround/PactMockServer.java
+++ b/knitter/src/test/java/org/sheepy/knitter/pactworkaround/PactMockServer.java
@@ -1,0 +1,22 @@
+package org.sheepy.knitter.pactworkaround;
+
+// Cannot be a record. Otherwise, it fails again with xstream
+public class PactMockServer {
+
+    private final String url;
+    private final int port;
+
+    public PactMockServer(String url, int port) {
+        this.url = url;
+        this.port = port;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    // Not used, but maybe somebody needs that.
+    public int getPort() {
+        return port;
+    }
+}

--- a/knitter/src/test/java/org/sheepy/knitter/pactworkaround/PactMockServerWorkaround.java
+++ b/knitter/src/test/java/org/sheepy/knitter/pactworkaround/PactMockServerWorkaround.java
@@ -1,0 +1,44 @@
+package org.sheepy.knitter.pactworkaround;
+
+import java.util.List;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.junit5.ProviderInfo;
+import kotlin.Pair;
+
+public class PactMockServerWorkaround implements ParameterResolver {
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+
+        return parameterContext.getParameter().getType() == PactMockServer.class;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+
+        // This is all super hacky, but it works. I guess Markus will kill me though,
+        // because we have already so many workarounds ;) Looking forward to junit 5.10 <3.
+        final ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.create("pact-jvm"));
+
+        if (store.get("providers") == null) {
+            return null;
+        }
+
+        final List<Pair<ProviderInfo, List<String>>> providers = store.get("providers", List.class);
+        var pair = providers.get(0);
+        final ProviderInfo providerInfo = pair.getFirst();
+
+        var mockServer = store.get("mockServer:" + providerInfo.getProviderName(),
+                MockServer.class);
+
+        return new PactMockServer(mockServer.getUrl(),
+                mockServer.getPort());
+    }
+}

--- a/knitter/src/test/java/org/sheepy/knitter/wiremock/InjectWireMock.java
+++ b/knitter/src/test/java/org/sheepy/knitter/wiremock/InjectWireMock.java
@@ -1,0 +1,11 @@
+package org.sheepy.knitter.wiremock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface InjectWireMock {
+}

--- a/knitter/src/test/java/org/sheepy/knitter/wiremock/WireMockQuarkusTestResource.java
+++ b/knitter/src/test/java/org/sheepy/knitter/wiremock/WireMockQuarkusTestResource.java
@@ -1,0 +1,69 @@
+package org.sheepy.knitter.wiremock;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.Notifier;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class WireMockQuarkusTestResource implements QuarkusTestResourceLifecycleManager {
+    private static final Logger LOGGER = Logger.getLogger(WireMockQuarkusTestResource.class);
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        final HashMap<String, String> result = new HashMap<>();
+
+        this.wireMockServer = new WireMockServer(options()
+                .dynamicPort()
+                .notifier(createNotifier(true)));
+        this.wireMockServer.start();
+
+        result.put("quarkus.rest-client.farmer-api.url", wireMockServer.baseUrl()/* + "/someBasePath"*/);
+
+        return result;
+    }
+
+    @Override
+    public void stop() {
+        if (this.wireMockServer != null) {
+            this.wireMockServer.stop();
+            this.wireMockServer = null;
+        }
+    }
+
+    @Override
+    public void inject(final TestInjector testInjector) {
+        testInjector.injectIntoFields(wireMockServer,
+                new TestInjector.AnnotatedAndMatchesType(InjectWireMock.class, WireMockServer.class));
+    }
+
+    private static Notifier createNotifier(final boolean verbose) {
+        // I like the emojis, It is easier for me to distinguish the different logs.
+        final String prefix = "\uD83C\uDF44 [WireMock] ";
+        return new Notifier() {
+
+            @Override
+            public void info(final String s) {
+                if (verbose) {
+                    LOGGER.info(prefix + s);
+                }
+            }
+
+            @Override
+            public void error(final String s) {
+                LOGGER.warn(prefix + s);
+            }
+
+            @Override
+            public void error(final String s, final Throwable throwable) {
+                LOGGER.warn(prefix + s, throwable);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This is not really a PR, but helps to see what I changed. It contains the discussed Wiremock approach
https://github.com/quarkiverse/quarkus-pact/issues/60 and also a fix for https://github.com/quarkiverse/quarkus-pact/issues/73

There might be different approaches how to init the proxy setup for WireMock. At the moment it is called in all test methods. I was struggling with the order of the extensions. I hope it helps.